### PR TITLE
Add support for UPC-based lookups

### DIFF
--- a/lib/walmart_open/client.rb
+++ b/lib/walmart_open/client.rb
@@ -2,6 +2,7 @@ require "walmart_open/config"
 require "walmart_open/connection_manager"
 require "walmart_open/requests/search"
 require "walmart_open/requests/lookup"
+require "walmart_open/requests/upc_lookup"
 require "walmart_open/requests/taxonomy"
 require "walmart_open/requests/feed"
 
@@ -23,6 +24,10 @@ module WalmartOpen
 
     def lookup(item_id, params = {})
       connection.request(Requests::Lookup.new(item_id, params))
+    end
+
+    def upc_lookup(upc)
+      connection.request(Requests::UpcLookup.new(upc))
     end
 
     def taxonomy

--- a/lib/walmart_open/requests/upc_lookup.rb
+++ b/lib/walmart_open/requests/upc_lookup.rb
@@ -1,0 +1,14 @@
+require "walmart_open/request"
+require "walmart_open/item"
+require "walmart_open/errors"
+
+module WalmartOpen
+  module Requests
+    class UpcLookup < Lookup
+      def initialize(upc)
+        self.path = "items"
+        self.params = {upc: upc}
+      end
+    end
+  end
+end

--- a/spec/walmart_open/client_spec.rb
+++ b/spec/walmart_open/client_spec.rb
@@ -64,6 +64,23 @@ describe WalmartOpen::Client do
     end
   end
 
+  context "#upc_lookup" do
+    it 'generates a lookup request for a UPC' do
+      client = WalmartOpen::Client.new
+      params = double
+      request = double
+      upc = double
+
+      expect(WalmartOpen::Requests::UpcLookup).to receive(:new) do |upc|
+        expect(upc).to eq(upc)
+        request
+      end
+      expect(client.connection).to receive(:request).with(request)
+
+      client.upc_lookup(params)
+    end
+  end
+
   context "#taxonomy" do
     it "delegates the request and returns the response" do
       client = WalmartOpen::Client.new


### PR DESCRIPTION
Lookups using UPCs look very similar to item id based lookups, but omit
the item id. Instead, they use a `upc` query param. This adds a new
request type which will remove the trailing slash from the `items` path
and set the UPC parameter based on user input.