### PR TITLE
Add support for LinkShare Publisher IDs

### DIFF
--- a/lib/walmart_open/config.rb
+++ b/lib/walmart_open/config.rb
@@ -6,6 +6,7 @@ module WalmartOpen
                   :product_domain,
                   :product_version,
                   :product_api_key,
+                  :linkshare_id,
                   :product_calls_per_second
 
     def initialize(options = {})

--- a/lib/walmart_open/request.rb
+++ b/lib/walmart_open/request.rb
@@ -30,7 +30,8 @@ module WalmartOpen
     def build_params(client)
       {
         format: "json",
-        api_key: client.config.product_api_key
+        api_key: client.config.product_api_key,
+        lsPublisherId: client.config.linkshare_id
       }.merge(params || {})
     end
 


### PR DESCRIPTION
In order to use affiliate URLs from Walmart, it is necessary to provide
a publisher ID from LinkShare via the lsPublisherId param. This adds a
`linkshare_id` config param when setting up the client to send this
along on all requests.