### PR TITLE
Add support for LinkShare Publisher IDs

### DIFF
--- a/lib/walmart_open/config.rb
+++ b/lib/walmart_open/config.rb
@@ -6,6 +6,7 @@ module WalmartOpen
                   :product_domain,
                   :product_version,
                   :product_api_key,
+                  :linkshare_publisher_id,
                   :product_calls_per_second
 
     def initialize(options = {})

--- a/lib/walmart_open/request.rb
+++ b/lib/walmart_open/request.rb
@@ -28,10 +28,18 @@ module WalmartOpen
     end
 
     def build_params(client)
-      {
+      base_params = {
         format: "json",
         api_key: client.config.product_api_key
-      }.merge(params || {})
+      }
+
+      # In order to use affiliate URLs from Walmart, it is necessary to provide
+      # a publisher ID from LinkShare via the lsPublisherId param.
+      if client.config.linkshare_publisher_id
+        base_params[:ls_publisher_id] = client.config.linkshare_publisher_id
+      end
+
+      base_params.merge(params || {})
     end
 
     # Walmart API unofficially supports HTTPS so we rather hit that instead of

--- a/spec/walmart_open/config_spec.rb
+++ b/spec/walmart_open/config_spec.rb
@@ -12,16 +12,19 @@ describe WalmartOpen::Config do
       expect(config.product_domain).to eq("walmartlabs.api.mashery.com")
       expect(config.product_version).to eq("v1")
       expect(config.product_calls_per_second).to be(5)
+      expect(config.linkshare_publisher_id).to eq(nil)
     end
 
     it "allows setting configs" do
       config = WalmartOpen::Config.new({debug: true, product_domain: "test",
-                product_version: "test", product_calls_per_second: 1,
+                product_version: "test", linkshare_publisher_id: "test",
+                product_calls_per_second: 1,
               })
 
       expect(config.debug).to be(true)
       expect(config.product_domain).to eq("test")
       expect(config.product_version).to eq("test")
+      expect(config.linkshare_publisher_id).to eq("test")
       expect(config.product_calls_per_second).to be(1)
     end
   end


### PR DESCRIPTION
- Added spec to external PR https://github.com/listia/walmart_open/pull/18/files
- Added only send lsPublisherId when config includes it. 
Walmart doc: https://developer.walmartlabs.com/docs/read/Reviews_Api

Tests: 

1) Run the following code in rails console, add a trace log in walmart_open gem and see request url is 
https://walmartlabs.api.mashery.com/v1/items/5420733?format=json&apiKey=jd72e9a32235765ckrewbpfw&lsPublisherId=xluabc and see response back successfully and matches documentation: 

```
product_id = 5420733 
item = client.lookup(product_id)

 => #<WalmartOpen::Item:0x007fefebadb898 @raw_attributes={"itemId"=>5420733, "parentItemId"=>5420733, "name"=>"Fisher-Price - Rainforest Melodies & Lights Gym", "msrp"=>54.0, "salePrice"=>48.51, "upc"=>"027084414998", "categoryPath"=>"Baby/Baby Gear/Gyms & Playmats", "shortDescription"=>"&lt;p&gt;The Fisher-Price - Rainforest Melodies &amp; Lights Gym is packed with activities that can provide your baby with plenty of playtime fun throughout the day. The large quilted play mat is decorated with a rainforest scene and is surrounded by a satin border. The play mat has colorful rainbow arches over a large giraffe. It has 20 minutes of continuous music with four songs and three different modes to keep your baby engaged. The Fisher-Price - Rainforest Melodies &amp; Lights Gym has two satin butterflies, which fly above the baby and colored lights pulse while music plays. You can fasten your baby's favorite toys with two linking points, which are attached to the baby activity mat's rainbow arch. Mom or baby can activate Rainforest lights and music for this baby play mat.&lt;/p&gt;", "longDescription"=>"&lt;br&gt;&lt;b&gt;Fisher-Price - Rainforest Melodies &amp; Lights Gym:&lt;/b&gt;&lt;ul&gt;&lt;li&gt;Interactive gym helps encourage healthy development&lt;/li&gt;&lt;li&gt;The Fisher-Price Rainforest play mat features music, lights, nature sounds, games, and textures&lt;/li&gt;&lt;li&gt;20 minutes of mom-activated continuous music; four songs&lt;/li&gt;&lt;li&gt;Ultra-comfortable floor quilt is a soft place for baby play or rest&lt;/li&gt;&lt;li&gt;Three different modes of play keep baby alert and interested&lt;/li&gt;&lt;li&gt;Large play mat has quilted rainforest-theme surrounded by satin border&lt;/li&gt;&lt;li&gt;The baby play mat includes five repositionable toys&lt;/li&gt;&lt;li&gt;Two satin butterflies fly above baby as colored lights pulse&lt;/li&gt;&lt;li&gt;Large giraffe sits at the bottom of the rainbow arch&lt;/li&gt;&lt;li&gt;Rainbow arch has two linking points for link toys&lt;/li&gt;&lt;li&gt;Fisher-Price Rainforest play mat requires three C batteries (not included)&lt;/li&gt;&lt;/ul&gt;", "brandName"=>"Fisher-Price", "thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-b2e1/k2-_13368e67-74a4-42ba-9631-d0c6ec45e46a.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-257e/k2-_bdc3d488-c389-4cb1-bc7c-a2c2b2e1da26.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-30a9/k2-_e18165b3-83a3-4e02-8976-d81dbab89bf6.v1.jpg", "productTrackingUrl"=>"http://linksynergy.walmart.com/fs-bin/click?id=xluabc&offerid=223073.7200&type=14&catid=8&subid=0&hid=7200&tmpid=1082&RD_PARM1=http%253A%252F%252Fwww.walmart.com%252Fip%252FFisher-Price-Rainforest-Musical-Gym%252F5420733%253Faffp1%253DT840S5NybHrG4be8_UPAoMJvxiwnSWCS5cwpmSVrUec%2526affilsrc%253Dapi", "ninetySevenCentShipping"=>false, "standardShipRate"=>4.97, "marketplace"=>false, "shipToStore"=>true, "freeShipToStore"=>true, "modelNumber"=>"K4562", "productUrl"=>"http://c.affil.walmart.com/t/api01?l=http%3A%2F%2Fwww.walmart.com%2Fip%2FFisher-Price-Rainforest-Musical-Gym%2F5420733%3Faffp1%3DT840S5NybHrG4be8_UPAoMJvxiwnSWCS5cwpmSVrUec%26affilsrc%3Dapi%26veh%3Daff%26wmlspartner%3Dreadonlyapi", "customerRating"=>"4.653", "numReviews"=>715, "customerRatingImage"=>"http://i2.walmartimages.com/i/CustRating/4_7.gif", "categoryNode"=>"5427_86323_133041", "bundle"=>false, "clearance"=>false, "preOrder"=>false, "stock"=>"Available", "addToCartUrl"=>"http://c.affil.walmart.com/t/api01?l=http%3A%2F%2Faffil.walmart.com%2Fcart%2FaddToCart%3Fitems%3D5420733%7C1%26affp1%3DT840S5NybHrG4be8_UPAoMJvxiwnSWCS5cwpmSVrUec%26affilsrc%3Dapi%26veh%3Daff%26wmlspartner%3Dreadonlyapi", "affiliateAddToCartUrl"=>"http://linksynergy.walmart.com/fs-bin/click?id=xluabc&offerid=223073.7200&type=14&catid=8&subid=0&hid=7200&tmpid=1082&RD_PARM1=http%253A%252F%252Faffil.walmart.com%252Fcart%252FaddToCart%253Fitems%253D5420733%257C1%2526affp1%253DT840S5NybHrG4be8_UPAoMJvxiwnSWCS5cwpmSVrUec%2526affilsrc%253Dapi", "freeShippingOver50Dollars"=>true, "maxItemsInOrder"=>5, "giftOptions"=>{"allowGiftWrap"=>false, "allowGiftMessage"=>false, "allowGiftReceipt"=>false}, "imageEntities"=>[{"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-1d44/k2-_c597a5f7-b17c-4f3e-a59e-48d76d1686b8.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-f5f0/k2-_038bce08-82cb-4a5e-9f11-20fa1311aae1.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-b5be/k2-_4ad9efba-0c3d-420f-97f7-d63f77643870.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-f09a/k2-_76245da4-7d9d-43e3-9fd2-25b3e2a553a2.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-9c67/k2-_c6b02755-f1e3-418b-8a39-6aa1e44322fd.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-a9ae/k2-_5cbee23b-a26b-4a95-9132-88c9d70b02d6.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-6b0d/k2-_55171353-8d4c-460d-9e3a-3630c09e65be.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-8acd/k2-_cc594248-9b39-4ac7-be1d-d1e703321a18.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-2987/k2-_ea8a2e18-05d9-4f63-8c57-07745e1103c7.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-3607/k2-_c0b7e68d-e0a4-4207-a6d5-b9d825cbb864.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-2faa/k2-_f55dce50-72ee-4456-9008-8d28f9c19ee7.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-65cb/k2-_a027d18c-7d6b-4b2f-8736-20acbf5c2cb7.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-b2e1/k2-_13368e67-74a4-42ba-9631-d0c6ec45e46a.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-257e/k2-_bdc3d488-c389-4cb1-bc7c-a2c2b2e1da26.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-30a9/k2-_e18165b3-83a3-4e02-8976-d81dbab89bf6.v1.jpg", "entityType"=>"PRIMARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-f8b4/k2-_60f767b2-5899-4d78-ad05-79d57d8b3362.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-249b/k2-_f78e4b44-a898-4181-8a53-976270476d56.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-4d21/k2-_aed67279-116a-4cf5-953c-a45bf90d6dac.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-aa64/k2-_44dd116c-7fe0-400b-abba-f4e1a576d249.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-38b5/k2-_ba7ba0f3-cdff-4450-9d35-135d375b7a22.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-ca98/k2-_fc2eecb4-8b07-4780-af9d-be528fb4910e.v1.jpg", "entityType"=>"SECONDARY"}, {"thumbnailImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-e710/k2-_a842b149-3c90-4e58-ab57-1ec31cf870dd.v1.jpg", "mediumImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-f5aa/k2-_088ef7d2-fc91-43ef-ae46-505e941547f8.v1.jpg", "largeImage"=>"http://i5.walmartimages.com/dfw/dce07b8c-1947/k2-_a32760ed-7df6-4920-a9b3-d68b8a151ac7.v1.jpg", "entityType"=>"SECONDARY"}], "availableOnline"=>true}, @id=5420733, @name="Fisher-Price - Rainforest Melodies & Lights Gym", @price=48.51, @upc="027084414998", @category_node="5427_86323_133041", @short_description="&lt;p&gt;The Fisher-Price - Rainforest Melodies &amp; Lights Gym is packed with activities that can provide your baby with plenty of playtime fun throughout the day. The large quilted play mat is decorated with a rainforest scene and is surrounded by a satin border. The play mat has colorful rainbow arches over a large giraffe. It has 20 minutes of continuous music with four songs and three different modes to keep your baby engaged. The Fisher-Price - Rainforest Melodies &amp; Lights Gym has two satin butterflies, which fly above the baby and colored lights pulse while music plays. You can fasten your baby's favorite toys with two linking points, which are attached to the baby activity mat's rainbow arch. Mom or baby can activate Rainforest lights and music for this baby play mat.&lt;/p&gt;", @long_description="&lt;br&gt;&lt;b&gt;Fisher-Price - Rainforest Melodies &amp; Lights Gym:&lt;/b&gt;&lt;ul&gt;&lt;li&gt;Interactive gym helps encourage healthy development&lt;/li&gt;&lt;li&gt;The Fisher-Price Rainforest play mat features music, lights, nature sounds, games, and textures&lt;/li&gt;&lt;li&gt;20 minutes of mom-activated continuous music; four songs&lt;/li&gt;&lt;li&gt;Ultra-comfortable floor quilt is a soft place for baby play or rest&lt;/li&gt;&lt;li&gt;Three different modes of play keep baby alert and interested&lt;/li&gt;&lt;li&gt;Large play mat has quilted rainforest-theme surrounded by satin border&lt;/li&gt;&lt;li&gt;The baby play mat includes five repositionable toys&lt;/li&gt;&lt;li&gt;Two satin butterflies fly above baby as colored lights pulse&lt;/li&gt;&lt;li&gt;Large giraffe sits at the bottom of the rainbow arch&lt;/li&gt;&lt;li&gt;Rainbow arch has two linking points for link toys&lt;/li&gt;&lt;li&gt;Fisher-Price Rainforest play mat requires three C batteries (not included)&lt;/li&gt;&lt;/ul&gt;", @shipping_rate=4.97, @model_number="K4562", @url="http://c.affil.walmart.com/t/api01?l=http%3A%2F%2Fwww.walmart.com%2Fip%2FFisher-Price-Rainforest-Musical-Gym%2F5420733%3Faffp1%3DT840S5NybHrG4be8_UPAoMJvxiwnSWCS5cwpmSVrUec%26affilsrc%3Dapi%26veh%3Daff%26wmlspartner%3Dreadonlyapi", @available_online=true, @large_image="http://i5.walmartimages.com/dfw/dce07b8c-30a9/k2-_e18165b3-83a3-4e02-8976-d81dbab89bf6.v1.jpg", @thumbnail_image="http://i5.walmartimages.com/dfw/dce07b8c-b2e1/k2-_13368e67-74a4-42ba-9631-d0c6ec45e46a.v1.jpg", @medium_image="http://i5.walmartimages.com/dfw/dce07b8c-257e/k2-_bdc3d488-c389-4cb1-bc7c-a2c2b2e1da26.v1.jpg"> 
```

2) remove  config.linkshare_publisher_id = config_data["production"]["linkshare_publisher_id"] from above code, run the commands in rails console again and see the request url is  https://walmartlabs.api.mashery.com/v1/items/5420733?format=json&apiKey=jd72e9a32235765ckrewbpfw
and see response back successfully. 
